### PR TITLE
Download tile logs from S3 to workdir before reading

### DIFF
--- a/cmd/osmviews-builder/paint.go
+++ b/cmd/osmviews-builder/paint.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log"
 
 	"golang.org/x/sync/errgroup"
 )
@@ -144,6 +145,9 @@ func NewPainter(path string, numWeeks int, zoom uint8) (*Painter, error) {
 // Paint produces a GeoTIFF file from a set of weekly tile view counts.
 // Tile views at zoom level `zoom` become one pixel in the output GeoTIFF.
 func paint(path string, zoom uint8, tilecounts []io.Reader, ctx context.Context) error {
+	logger := log.Default()
+	logger.Printf("starting to paint GeoTIFF, path=%s, zoom=%d", path, zoom)
+
 	// One goroutine is decompressing, parsing and merging the weekly counts;
 	// another is painting the image from data that gets sent over a channel.
 	ch := make(chan TileCount, 100000)

--- a/cmd/osmviews-builder/storage_test.go
+++ b/cmd/osmviews-builder/storage_test.go
@@ -147,6 +147,35 @@ func TestCleanup(t *testing.T) {
 	}
 }
 
+func TestDownload(t *testing.T) {
+	remotePath := "remote/path.txt"
+	srcPath := filepath.Join(t.TempDir(), "test_download_src.txt")
+	destPath := filepath.Join(t.TempDir(), "test_download_dest.txt")
+	if err := os.WriteFile(srcPath, []byte("foo"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := NewFakeStorage()
+	ctx := context.Background()
+	if err := s.PutFile(ctx, "osmviews", remotePath, srcPath, "text/plain"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Download(s, "osmviews", remotePath, destPath); err != nil {
+		t.Fatal(err)
+	}
+
+	gotBytes, err := os.ReadFile(destPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(gotBytes)
+
+	if got != "foo" {
+		t.Errorf("expected \"foo\", got \"%s\"", got)
+	}
+}
+
 type FakeStorageObject struct {
 	Content []byte
 	Info    ObjectInfo


### PR DESCRIPTION
To produce the GeoTIFF output, we need to merge pre-processed log data of the past 52 weeks. When we build the weekly logs, we store the lines within in each file in a sorted order, so the Painter class can do an efficient merge of the 52 weeks by scanning through the inputs in parallel. However, some S3 object stores don't like it when a client opens 52 connections and scans through their content in parallel.

Apparently, when confronted with clients like ours, Ceph-based S3 object storage servers believe that they're under attack. As a mitigation measure, the S3 server randomly closes connections. In our client code, this connection shutdown manifests as random end-of-file errors.

To work around this, we first download the 52 tile logs to our working directory before reading them. By consequence, we need an additional 10G of empty local disk for the working directory to run the build pipeline in production. Which is a lot better than crashing due to random errors.