### PR TITLE
Take keys for S3 storage from envvars

### DIFF
--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -26,7 +26,6 @@ var ServerVersion = "OSMViews"
 
 func main() {
 	port := flag.Int("port", 0, "port for serving HTTP requests")
-	storagekey := flag.String("storage-key", "keys/storage-key", "path to key with storage access credentials")
 	workdir := flag.String("workdir", "webserver-workdir", "path to working directory on local disk")
 	flag.Parse()
 
@@ -34,7 +33,7 @@ func main() {
 		*port, _ = strconv.Atoi(os.Getenv("PORT"))
 	}
 
-	storage, err := NewStorage(*storagekey, *workdir)
+	storage, err := NewStorage(*workdir)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/webserver/storage.go
+++ b/cmd/webserver/storage.go
@@ -6,7 +6,6 @@ package main
 import (
 	"context"
 	"encoding/base32"
-	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -43,20 +42,15 @@ type storageClient interface {
 }
 
 // NewStorage sets up a client for accessing S3-compatible object storage.
-func NewStorage(keypath, workdir string) (*Storage, error) {
+func NewStorage(workdir string) (*Storage, error) {
 	if err := os.MkdirAll(workdir, 0755); err != nil {
 		return nil, err
 	}
 
-	data, err := os.ReadFile(keypath)
-	if err != nil {
-		return nil, err
-	}
-
 	var config struct{ Endpoint, Key, Secret string }
-	if err := json.Unmarshal(data, &config); err != nil {
-		return nil, err
-	}
+	config.Endpoint = os.Getenv("S3_ENDPOINT")
+	config.Key = os.Getenv("S3_KEY")
+	config.Secret = os.Getenv("S3_SECRET")
 
 	client, err := minio.New(config.Endpoint, &minio.Options{
 		Creds:  credentials.NewStaticV4(config.Key, config.Secret, ""),


### PR DESCRIPTION
Wikimedia Toolforge recommends reading secrets from environment variables instead of files.