### PR TITLE
Set a default workdir for osmviews-builder

### DIFF
--- a/cmd/osmviews-builder/main.go
+++ b/cmd/osmviews-builder/main.go
@@ -17,7 +17,7 @@ import (
 func main() {
 	ctx := context.Background()
 
-	workdir := flag.String("workdir", "", "path to working directory")
+	workdir := flag.String("workdir", "osmviews-builder-workdir", "path to working directory")
 	flag.Parse()
 
 	logger := log.Default()


### PR DESCRIPTION
In production, Wikimedia Toolforge does not allow passing command-line parameters to cronjobs. (We could have a custom shell script that executed our binary, but then we have another file which would add complexity).